### PR TITLE
oriafias/sc-6537/hide-grafana-sidebar

### DIFF
--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -126,7 +126,6 @@ export class AppWrapper extends React.Component<AppWrapperProps, AppWrapperState
                     {this.commandPaletteEnabled() && <CommandPalette />}
                     <div className="grafana-app">
                       <Router history={locationService.getHistory()}>
-                        {this.renderNavBar()}
                         <AppChrome>
                           {pageBanners.map((Banner, index) => (
                             <Banner key={index.toString()} />


### PR DESCRIPTION
![Screenshot from 2022-12-28 10-54-53](https://user-images.githubusercontent.com/98386380/209789827-eed07d13-6065-4df8-a873-0b790cecf685.png)

i didn't want to make any dramatic changes like removing the whole `NavBar` component in case we'd want it back and for rebasing the official repo more easily later.

lmk if we should remove the whole `NavBar` implementation