### PR TITLE
oriafias/sc-6697/stretch-dashbord-modal-to-fit-screen

### DIFF
--- a/packages/grafana-ui/src/themes/GlobalStyles/page.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/page.ts
@@ -25,6 +25,10 @@ export function getPageStyles(theme: GrafanaTheme2) {
       height: 100%;
       flex: 1 1 0;
       min-width: 0;
+
+      & .css-1x0t2fg {
+        left: 0;
+      }
     }
 
     .page-scrollbar-content {


### PR DESCRIPTION
## Description
inside dashboards page and choosing the k8s dashboard, we can click `K8S` again in the breadcrumbs, the same dashboard opens again but it doesn't take the full width. it keeps space for the side bar we've removed.

## Fix
i couldn't find the specific modal component as it's selected dynamically. i couldn't figure out the whole flow, but i found the father component and edited the relevant child via css

## Before
![Screenshot 2023-01-04 at 14 19 58 (2)](https://user-images.githubusercontent.com/98386380/210555660-ce556cb5-f069-49bf-bcb6-a96706ec1f6f.png)

## After
![Screenshot 2023-01-04 at 14 34 50](https://user-images.githubusercontent.com/98386380/210556280-58673d14-4bdf-4470-bec3-bfa7683a33a5.png)
