### PR TITLE
Oriafias/sc 6713/chart containers design tweaks

### DIFF
--- a/public/sass/components/_panel_header.scss
+++ b/public/sass/components/_panel_header.scss
@@ -31,9 +31,8 @@ $panel-header-no-title-zindex: 1;
   flex-wrap: nowrap;
   line-height: $panel-header-height;
   align-items: center;
-  margin-top: 10px;
   justify-content: space-between;
-  padding: 0 35px;
+  padding: 0 35px 0 15px;
   & h2 {
     @import url('https://fonts.googleapis.com/css2?family=Lato:wght@700&display=swap');
     font-family: 'Lato', sans-serif;

--- a/public/sass/components/_panel_header.scss
+++ b/public/sass/components/_panel_header.scss
@@ -1,12 +1,5 @@
 $panel-header-no-title-zindex: 1;
 
-.panel-header {
-  &:hover {
-    transition: background-color 0.1s ease-in-out;
-    background-color: $panel-header-hover-bg;
-  }
-}
-
 .panel-container--no-title {
   .panel-header {
     position: absolute;
@@ -32,15 +25,22 @@ $panel-header-no-title-zindex: 1;
 
 .panel-title {
   border: 0px;
-  font-weight: $font-weight-semi-bold;
   position: relative;
   width: 100%;
   display: flex;
   flex-wrap: nowrap;
-  justify-content: center;
-  height: $panel-header-height;
   line-height: $panel-header-height;
   align-items: center;
+  margin-top: 10px;
+  justify-content: space-between;
+  padding: 0 35px;
+  & h2 {
+    @import url('https://fonts.googleapis.com/css2?family=Lato:wght@700&display=swap');
+    font-family: 'Lato', sans-serif;
+    text-transform: uppercase;
+    font-size: 15px;
+    font-weight: 700;
+  }
 }
 
 .panel-menu-container {

--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -9,15 +9,15 @@
 
 .panel-container {
   background-color: $panel-bg;
-  border: $panel-border;
+  border: 0.5px solid #00000026;
   position: relative;
-  border-radius: 3px;
+  border-radius: 8px;
   height: 100%;
   width: 100%;
   display: flex;
   flex-direction: column;
   flex: 1 1 0;
-  box-shadow: $panel-box-shadow;
+  box-shadow: 0px 1px 0.5px 0px '#00000026';
 
   &--transparent {
     background-color: transparent;


### PR DESCRIPTION
* removed header background on hover.
* removed header pointer (previously `move` but the charts are not draggable anymore).
* header typography (font size, weight, color, family).
* header spacing and directions (aligned text to the left and chevron icon to the right).
* container border, radius and shadow

_notice: since these are `scss` files, and they are pre-compiled with the `full_stack.sh` script, when changing the styles you need to run the script again. it's annoying i know :(_

### Before
![image](https://user-images.githubusercontent.com/98386380/211190818-8c22bc46-ed04-4c59-add4-cb63764cca48.png)
![image](https://user-images.githubusercontent.com/98386380/211190908-dea9eb6d-5040-494d-9914-220cfe92626b.png)


### After
![image](https://user-images.githubusercontent.com/98386380/211190799-fd608e53-366e-449a-8bdf-175271433f31.png)
![image](https://user-images.githubusercontent.com/98386380/211190923-49e902ef-521f-4fe2-bfc0-c89a708a8752.png)

