### PR TITLE
CORE-9708 - Labels as string for monitor templating

### DIFF
--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -349,7 +349,7 @@ func StatesToStream(rule history_model.RuleMeta, states []state.StateTransition,
 			template.SummaryContext{
 				MonitorName: rule.Title,
 				Severity:    labelMap[models.GCSeverityLabel],
-				Labels:      labelMap,
+				Labels:      template.Labels(labelMap),
 				Fingerprint: fingerprint,
 				Value:       state.State.Values[models.GCThresholdInputQueryKey],
 				Threshold:   state.State.Values[models.GCThreshold1Key],

--- a/pkg/services/ngalert/state/template/jinja2.go
+++ b/pkg/services/ngalert/state/template/jinja2.go
@@ -16,7 +16,7 @@ func init() {
 type SummaryContext struct {
 	MonitorName string
 	Severity    string
-	Labels      map[string]string
+	Labels      Labels
 	Fingerprint string
 	Value       float64
 	Threshold   float64

--- a/pkg/services/ngalert/state/template/jinja2_test.go
+++ b/pkg/services/ngalert/state/template/jinja2_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestExpandJinja2Summary_BasicVariables(t *testing.T) {
 	ctx := SummaryContext{
-		Labels: map[string]string{
+		Labels: Labels{
 			"pod":       "web-1",
 			"namespace": "prod",
 		},
@@ -22,7 +22,7 @@ func TestExpandJinja2Summary_BasicVariables(t *testing.T) {
 
 func TestExpandJinja2Summary_NoTemplateMarkers(t *testing.T) {
 	ctx := SummaryContext{
-		Labels: map[string]string{"pod": "web-1"},
+		Labels: Labels{"pod": "web-1"},
 	}
 
 	result, err := ExpandJinja2Summary("Plain text without markers", ctx)
@@ -33,7 +33,7 @@ func TestExpandJinja2Summary_NoTemplateMarkers(t *testing.T) {
 
 func TestExpandJinja2Summary_InvalidSyntax(t *testing.T) {
 	ctx := SummaryContext{
-		Labels: map[string]string{"pod": "web-1"},
+		Labels: Labels{"pod": "web-1"},
 	}
 
 	_, err := ExpandJinja2Summary("{{ invalid syntax {% ", ctx)
@@ -45,7 +45,7 @@ func TestExpandJinja2Summary_InvalidSyntax(t *testing.T) {
 
 func TestExpandJinja2Summary_MissingLabel(t *testing.T) {
 	ctx := SummaryContext{
-		Labels: map[string]string{"pod": "web-1"},
+		Labels: Labels{"pod": "web-1"},
 	}
 
 	result, err := ExpandJinja2Summary("{{ labels.nonexistent }}{{ alert.labels.nonexistent }}", ctx)
@@ -56,7 +56,7 @@ func TestExpandJinja2Summary_MissingLabel(t *testing.T) {
 
 func TestExpandJinja2Summary_EmptyLabels(t *testing.T) {
 	ctx := SummaryContext{
-		Labels: map[string]string{},
+		Labels: Labels{},
 	}
 
 	result, err := ExpandJinja2Summary("{{ labels.pod }}{{ alert.labels.pod }}", ctx)
@@ -76,7 +76,7 @@ func TestExpandJinja2Summary_NilLabels(t *testing.T) {
 
 func TestExpandJinja2Summary_SpecialCharactersInLabels(t *testing.T) {
 	ctx := SummaryContext{
-		Labels: map[string]string{
+		Labels: Labels{
 			"pod": "web-1 <test> & \"special\"",
 		},
 	}
@@ -89,7 +89,7 @@ func TestExpandJinja2Summary_SpecialCharactersInLabels(t *testing.T) {
 
 func TestExpandJinja2Summary_MultiplePlaceholders(t *testing.T) {
 	ctx := SummaryContext{
-		Labels: map[string]string{
+		Labels: Labels{
 			"pod":       "web-1",
 			"namespace": "prod",
 			"service":   "api",
@@ -106,7 +106,7 @@ func TestExpandJinja2Summary_MultiplePlaceholders(t *testing.T) {
 
 func TestExpandJinja2Summary_EmptyTemplate(t *testing.T) {
 	ctx := SummaryContext{
-		Labels: map[string]string{"pod": "web-1"},
+		Labels: Labels{"pod": "web-1"},
 	}
 
 	result, err := ExpandJinja2Summary("", ctx)
@@ -219,7 +219,7 @@ func TestExpandJinja2Summary_AllFields(t *testing.T) {
 	ctx := SummaryContext{
 		MonitorName: "High CPU",
 		Severity:    "warning",
-		Labels: map[string]string{
+		Labels: Labels{
 			"pod":       "web-1",
 			"namespace": "prod",
 		},
@@ -236,4 +236,47 @@ func TestExpandJinja2Summary_AllFields(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, "[warning] High CPU(High CPU): web-1(web-1) in prod(prod) - Alerting (85.500000/80.000000) query=cpu > 80 by=ops-team fingerprint=abc123(abc123)", result)
+}
+
+func TestExpandJinja2Summary_LabelsString(t *testing.T) {
+	ctx := SummaryContext{
+		Labels: Labels{
+			"namespace": "prod",
+			"pod":       "web-1",
+			"service":   "api",
+		},
+	}
+
+	result, err := ExpandJinja2Summary("Labels: {{ labels }}", ctx)
+
+	require.NoError(t, err)
+	require.Equal(t, "Labels: namespace=prod, pod=web-1, service=api", result)
+
+	result, err = ExpandJinja2Summary("Labels: {{ alert.labels }}", ctx)
+
+	require.NoError(t, err)
+	require.Equal(t, "Labels: namespace=prod, pod=web-1, service=api", result)
+}
+
+func TestExpandJinja2Summary_LabelsForLoop(t *testing.T) {
+	ctx := SummaryContext{
+		Labels: Labels{
+			"pod":       "web-1",
+			"namespace": "prod",
+		},
+	}
+
+	tmpl := `{% for label in labels %}{{ label }}={{ labels[label] }} {% endfor %}`
+	result, err := ExpandJinja2Summary(tmpl, ctx)
+
+	require.NoError(t, err)
+	require.Contains(t, result, "namespace=prod")
+	require.Contains(t, result, "pod=web-1")
+
+	tmpl = `{% for key, val in alert.labels %}{{ key }}={{ val }} {% endfor %}`
+	result, err = ExpandJinja2Summary(tmpl, ctx)
+
+	require.NoError(t, err)
+	require.Contains(t, result, "namespace=prod")
+	require.Contains(t, result, "pod=web-1")
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for label handling in alert summary templates, validating string representation of labels, iteration patterns, and key-value pair access for alert references.

* **Refactor**
  * Updated the label data structure in alert summary context to improve how labels are managed and accessed within notification templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->