### PR TITLE
BE-795 - Support dot-notation label keys in Jinja2 template rendering

### DIFF
--- a/pkg/services/ngalert/state/template/jinja2.go
+++ b/pkg/services/ngalert/state/template/jinja2.go
@@ -59,15 +59,32 @@ func BuildNestedLabels(labels Labels) NestedLabels {
 	// Second pass: build nested structure for dotted keys (enables dot notation).
 	// If an intermediate segment conflicts with an existing flat leaf value,
 	// we skip building the nested path for that key to preserve backward compatibility.
-	for k, v := range labels {
+	//
+	// Keys are sorted by segment count (fewer segments first) to ensure deterministic
+	// behavior when keys overlap (e.g., "a.b" and "a.b.c"). Shorter keys are processed
+	// first so they claim their leaf position, and deeper keys correctly detect the conflict.
+	type dottedKey struct {
+		key   string
+		parts []string
+	}
+	var dottedKeys []dottedKey
+	for k := range labels {
 		parts := strings.Split(k, ".")
-		if len(parts) == 1 {
-			continue // No dots — already handled by first pass.
+		if len(parts) > 1 {
+			dottedKeys = append(dottedKeys, dottedKey{key: k, parts: parts})
 		}
+	}
+	sort.Slice(dottedKeys, func(i, j int) bool {
+		if len(dottedKeys[i].parts) != len(dottedKeys[j].parts) {
+			return len(dottedKeys[i].parts) < len(dottedKeys[j].parts)
+		}
+		return dottedKeys[i].key < dottedKeys[j].key
+	})
 
+	for _, dk := range dottedKeys {
 		current := map[string]interface{}(result)
 		conflict := false
-		for _, part := range parts[:len(parts)-1] {
+		for _, part := range dk.parts[:len(dk.parts)-1] {
 			if existing, ok := current[part]; ok {
 				if nestedMap, ok := existing.(map[string]interface{}); ok {
 					current = nestedMap
@@ -84,7 +101,7 @@ func BuildNestedLabels(labels Labels) NestedLabels {
 			}
 		}
 		if !conflict {
-			current[parts[len(parts)-1]] = v
+			current[dk.parts[len(dk.parts)-1]] = labels[dk.key]
 		}
 	}
 
@@ -119,10 +136,12 @@ func ExpandJinja2Summary(tmpl string, ctx SummaryContext) (string, error) {
 		return tmpl, nil
 	}
 
+	nestedLabels := BuildNestedLabels(ctx.Labels)
+
 	pongoCtx := pongo2.Context{
 		"monitor_name": ctx.MonitorName,
 		"severity":     ctx.Severity,
-		"labels":       BuildNestedLabels(ctx.Labels),
+		"labels":       nestedLabels,
 		"value":        ctx.Value,
 		"threshold":    ctx.Threshold,
 		"state":        ctx.State,
@@ -131,7 +150,7 @@ func ExpandJinja2Summary(tmpl string, ctx SummaryContext) (string, error) {
 		"fingerprint":  ctx.Fingerprint,
 		// Legacy support for alert. prefix (Keep workflows)
 		"alert": map[string]any{
-			"labels":      BuildNestedLabels(ctx.Labels),
+			"labels":      nestedLabels,
 			"fingerprint": ctx.Fingerprint,
 			"alertname":   ctx.MonitorName,
 		},

--- a/pkg/services/ngalert/state/template/jinja2.go
+++ b/pkg/services/ngalert/state/template/jinja2.go
@@ -1,10 +1,95 @@
 package template
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/flosch/pongo2/v6"
 )
+
+// NestedLabels is a map[string]interface{} that supports both bracket notation
+// (flat key lookup) and dot notation (nested traversal) for keys containing dots.
+// It preserves the original Labels.String() formatting for direct {{ labels }} interpolation.
+type NestedLabels map[string]interface{}
+
+func (l NestedLabels) String() string {
+	if len(l) == 0 {
+		return ""
+	}
+
+	// Collect only leaf string values (original flat keys), skip nested map entries.
+	keys := make([]string, 0, len(l))
+	for k, v := range l {
+		if _, isMap := v.(map[string]interface{}); !isMap {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	pairs := make([]string, 0, len(keys))
+	for _, k := range keys {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", k, l[k]))
+	}
+	return strings.Join(pairs, ", ")
+}
+
+// BuildNestedLabels converts a flat Labels map into a NestedLabels that
+// supports both bracket notation and dot notation for keys containing dots.
+//
+// For a flat map like {"http.route": "/api", "env": "prod"}, the result is:
+//
+//	{
+//	  "http.route": "/api",          // flat key preserved for labels["http.route"]
+//	  "http": {"route": "/api"},     // nested entry for labels.http.route
+//	  "env": "prod",                 // simple key, works both ways
+//	}
+func BuildNestedLabels(labels Labels) NestedLabels {
+	if len(labels) == 0 {
+		return nil
+	}
+
+	result := make(NestedLabels, len(labels)*2)
+
+	// First pass: add all original flat keys (preserves bracket notation).
+	for k, v := range labels {
+		result[k] = v
+	}
+
+	// Second pass: build nested structure for dotted keys (enables dot notation).
+	// If an intermediate segment conflicts with an existing flat leaf value,
+	// we skip building the nested path for that key to preserve backward compatibility.
+	for k, v := range labels {
+		parts := strings.Split(k, ".")
+		if len(parts) == 1 {
+			continue // No dots — already handled by first pass.
+		}
+
+		current := map[string]interface{}(result)
+		conflict := false
+		for _, part := range parts[:len(parts)-1] {
+			if existing, ok := current[part]; ok {
+				if nestedMap, ok := existing.(map[string]interface{}); ok {
+					current = nestedMap
+				} else {
+					// Intermediate part exists as a flat leaf value (e.g., "github" is a simple label).
+					// Skip building nested path to avoid overwriting the leaf.
+					conflict = true
+					break
+				}
+			} else {
+				nested := make(map[string]interface{})
+				current[part] = nested
+				current = nested
+			}
+		}
+		if !conflict {
+			current[parts[len(parts)-1]] = v
+		}
+	}
+
+	return result
+}
 
 func init() {
 	// Disable auto-escaping globally for pongo2.
@@ -37,7 +122,7 @@ func ExpandJinja2Summary(tmpl string, ctx SummaryContext) (string, error) {
 	pongoCtx := pongo2.Context{
 		"monitor_name": ctx.MonitorName,
 		"severity":     ctx.Severity,
-		"labels":       ctx.Labels,
+		"labels":       BuildNestedLabels(ctx.Labels),
 		"value":        ctx.Value,
 		"threshold":    ctx.Threshold,
 		"state":        ctx.State,
@@ -46,7 +131,7 @@ func ExpandJinja2Summary(tmpl string, ctx SummaryContext) (string, error) {
 		"fingerprint":  ctx.Fingerprint,
 		// Legacy support for alert. prefix (Keep workflows)
 		"alert": map[string]any{
-			"labels":      ctx.Labels,
+			"labels":      BuildNestedLabels(ctx.Labels),
 			"fingerprint": ctx.Fingerprint,
 			"alertname":   ctx.MonitorName,
 		},

--- a/pkg/services/ngalert/state/template/jinja2_test.go
+++ b/pkg/services/ngalert/state/template/jinja2_test.go
@@ -305,10 +305,19 @@ func TestExpandJinja2Summary_DotNotationConflict(t *testing.T) {
 		},
 	}
 
+	// Flat leaf value wins — dot notation resolves to the simple label.
 	result, err := ExpandJinja2Summary("Org: {{ labels.github }}", ctx)
-
 	require.NoError(t, err)
 	require.Equal(t, "Org: myorg", result)
+
+	// Dot notation for the conflicted key errors (pongo2 can't traverse a string).
+	_, err = ExpandJinja2Summary("Workflow: {{ labels.github.workflow }}", ctx)
+	require.Error(t, err)
+
+	// Bracket notation still works as the fallback for conflicted dotted keys.
+	result, err = ExpandJinja2Summary(`Workflow: {{ labels["github.workflow"] }}`, ctx)
+	require.NoError(t, err)
+	require.Equal(t, "Workflow: CI", result)
 }
 
 func TestExpandJinja2Summary_MixedSimpleAndDottedKeys(t *testing.T) {
@@ -362,6 +371,22 @@ func TestBuildNestedLabels(t *testing.T) {
 		require.Equal(t, "CI", result["github.workflow"])
 	})
 
+	t.Run("overlapping dotted keys are deterministic", func(t *testing.T) {
+		// "a.b" (2 segments) is always processed before "a.b.c" (3 segments),
+		// so "a.b" claims the leaf and "a.b.c" nesting is skipped.
+		for i := 0; i < 100; i++ {
+			result := BuildNestedLabels(Labels{
+				"a.b":   "1",
+				"a.b.c": "2",
+			})
+			aMap, ok := result["a"].(map[string]interface{})
+			require.True(t, ok, "iteration %d: result[\"a\"] should be a map", i)
+			require.Equal(t, "1", aMap["b"], "iteration %d: shorter key a.b must always win", i)
+			require.Equal(t, "1", result["a.b"])
+			require.Equal(t, "2", result["a.b.c"])
+		}
+	})
+
 	t.Run("String skips nested map entries", func(t *testing.T) {
 		result := BuildNestedLabels(Labels{"env": "prod", "http.route": "/api"})
 		s := result.String()
@@ -392,4 +417,28 @@ func TestExpandJinja2Summary_LabelsForLoop(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, result, "namespace=prod")
 	require.Contains(t, result, "pod=web-1")
+}
+
+func TestExpandJinja2Summary_LabelsForLoopWithDottedKeys(t *testing.T) {
+	ctx := SummaryContext{
+		Labels: Labels{
+			"env":        "prod",
+			"http.route": "/api",
+		},
+	}
+
+	// {{ labels }} stringification filters out synthetic nested map entries.
+	result, err := ExpandJinja2Summary("{{ labels }}", ctx)
+	require.NoError(t, err)
+	require.Equal(t, "env=prod, http.route=/api", result)
+
+	// For-loop iteration sees synthetic keys (e.g., "http") alongside original flat keys.
+	// This is a known tradeoff: dot notation (labels.http.route) requires the nested
+	// structure to live in the same map. Use {{ labels }} for clean output.
+	tmpl := `{% for key, val in labels %}{{ key }},{% endfor %}`
+	result, err = ExpandJinja2Summary(tmpl, ctx)
+	require.NoError(t, err)
+	require.Contains(t, result, "env,")
+	require.Contains(t, result, "http.route,")
+	require.Contains(t, result, "http,")
 }

--- a/pkg/services/ngalert/state/template/jinja2_test.go
+++ b/pkg/services/ngalert/state/template/jinja2_test.go
@@ -258,6 +258,119 @@ func TestExpandJinja2Summary_LabelsString(t *testing.T) {
 	require.Equal(t, "Labels: namespace=prod, pod=web-1, service=api", result)
 }
 
+func TestExpandJinja2Summary_DotNotationLabels(t *testing.T) {
+	ctx := SummaryContext{
+		Labels: Labels{
+			"http.route": "/api/v1/users",
+		},
+	}
+
+	result, err := ExpandJinja2Summary("Route: {{ labels.http.route }}", ctx)
+
+	require.NoError(t, err)
+	require.Equal(t, "Route: /api/v1/users", result)
+}
+
+func TestExpandJinja2Summary_DeepDotNotation(t *testing.T) {
+	ctx := SummaryContext{
+		Labels: Labels{
+			"user.properties.tenantUUID": "abc-123",
+		},
+	}
+
+	result, err := ExpandJinja2Summary("Tenant: {{ labels.user.properties.tenantUUID }}", ctx)
+
+	require.NoError(t, err)
+	require.Equal(t, "Tenant: abc-123", result)
+}
+
+func TestExpandJinja2Summary_BracketNotationPreserved(t *testing.T) {
+	ctx := SummaryContext{
+		Labels: Labels{
+			"http.route": "/api/v1/users",
+		},
+	}
+
+	result, err := ExpandJinja2Summary(`Route: {{ labels["http.route"] }}`, ctx)
+
+	require.NoError(t, err)
+	require.Equal(t, "Route: /api/v1/users", result)
+}
+
+func TestExpandJinja2Summary_DotNotationConflict(t *testing.T) {
+	ctx := SummaryContext{
+		Labels: Labels{
+			"github":          "myorg",
+			"github.workflow": "CI",
+		},
+	}
+
+	result, err := ExpandJinja2Summary("Org: {{ labels.github }}", ctx)
+
+	require.NoError(t, err)
+	require.Equal(t, "Org: myorg", result)
+}
+
+func TestExpandJinja2Summary_MixedSimpleAndDottedKeys(t *testing.T) {
+	ctx := SummaryContext{
+		Labels: Labels{
+			"env":        "prod",
+			"http.route": "/api",
+		},
+	}
+
+	result, err := ExpandJinja2Summary("{{ labels.env }} {{ labels.http.route }}", ctx)
+
+	require.NoError(t, err)
+	require.Equal(t, "prod /api", result)
+}
+
+func TestBuildNestedLabels(t *testing.T) {
+	t.Run("nil for empty labels", func(t *testing.T) {
+		result := BuildNestedLabels(Labels{})
+		require.Nil(t, result)
+	})
+
+	t.Run("simple keys preserved", func(t *testing.T) {
+		result := BuildNestedLabels(Labels{"env": "prod", "pod": "web-1"})
+		require.Equal(t, "prod", result["env"])
+		require.Equal(t, "web-1", result["pod"])
+	})
+
+	t.Run("dotted key creates flat and nested entries", func(t *testing.T) {
+		result := BuildNestedLabels(Labels{"http.route": "/api"})
+		require.Equal(t, "/api", result["http.route"])
+		httpMap, ok := result["http"].(map[string]interface{})
+		require.True(t, ok)
+		require.Equal(t, "/api", httpMap["route"])
+	})
+
+	t.Run("deep nesting", func(t *testing.T) {
+		result := BuildNestedLabels(Labels{"a.b.c": "val"})
+		require.Equal(t, "val", result["a.b.c"])
+		aMap := result["a"].(map[string]interface{})
+		bMap := aMap["b"].(map[string]interface{})
+		require.Equal(t, "val", bMap["c"])
+	})
+
+	t.Run("conflict preserves flat leaf", func(t *testing.T) {
+		result := BuildNestedLabels(Labels{
+			"github":          "myorg",
+			"github.workflow": "CI",
+		})
+		require.Equal(t, "myorg", result["github"])
+		require.Equal(t, "CI", result["github.workflow"])
+	})
+
+	t.Run("String skips nested map entries", func(t *testing.T) {
+		result := BuildNestedLabels(Labels{"env": "prod", "http.route": "/api"})
+		s := result.String()
+		require.Contains(t, s, "env=prod")
+		require.Contains(t, s, "http.route=/api")
+		require.NotContains(t, s, "http=map")
+	})
+}
+
 func TestExpandJinja2Summary_LabelsForLoop(t *testing.T) {
 	ctx := SummaryContext{
 		Labels: Labels{


### PR DESCRIPTION
## Summary

- Port `BuildNestedLabels` from dispatch-center to fix Jinja2 template rendering for label keys containing dots (e.g., `http.route`, `user.email`, `user.properties.tenantUUID`)
- Monitor headers using `{{ labels.http.route }}` were written to `monitor_state.summary` unrendered because pongo2 couldn't resolve dot-notation against a flat `map[string]string`

## Problem

The Grafana fork's `ExpandJinja2Summary` passes labels as a flat `map[string]string` to pongo2. When pongo2 evaluates `{{ labels.http.route }}`, it looks up `labels["http"]` which doesn't exist — the actual key is `"http.route"`. This causes the template to render as empty, and the raw template string ends up in ClickHouse `monitor_state.summary`.

The dispatch-center already solved this with `BuildNestedLabels()` which creates a nested map structure, so `labels.http.route` resolves through `labels["http"]["route"]`.

## Changes

**`jinja2.go`**:
- Added `NestedLabels` type (`map[string]interface{}`) with `String()` that preserves the original `key=value` format (skips nested map entries)
- Added `BuildNestedLabels(labels Labels) NestedLabels` — two-pass algorithm:
  1. Copies all flat keys as-is (preserves bracket notation `labels["http.route"]`)
  2. Builds nested maps for dotted keys (enables dot notation `labels.http.route`)
  3. Skips nesting when intermediate segments conflict with existing flat leaf values
- Updated `ExpandJinja2Summary` to wrap labels with `BuildNestedLabels()` for both `labels` and `alert.labels`

**`jinja2_test.go`** — 6 new test functions covering dot notation, deep nesting, bracket notation, conflict handling, mixed keys, and `BuildNestedLabels` unit tests.

## Testing

All 92 tests pass: `go test ./pkg/services/ngalert/state/template/...`

Linear: https://linear.app/groundcover/issue/BE-795

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Templates now support dot-notation for nested label access while preserving existing bracket/flat-key access; alert label context exposes the nested view for templates.
  * Label collections render deterministically as sorted, comma-separated key=value strings for leaf entries.

* **Tests**
  * Added extensive tests covering dot/bracket notation, deep nesting, conflict cases, loops over labels, and deterministic ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->