### PR TITLE
BE-669: Extract configured threshold into alert state Values map

### DIFF
--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -366,7 +366,7 @@ func (st *Manager) updateLastSentAt(states StateTransitions, evaluatedAt time.Ti
 
 func (st *Manager) setNextStateForRule(ctx context.Context, alertRule *ngModels.AlertRule, results eval.Results, extraLabels data.Labels, logger log.Logger) []StateTransition {
 	// Extract the configured threshold once per rule evaluation, not per result.
-	thresholdVal, thresholdOK := extractConfiguredThreshold(alertRule)
+	threshold := extractConfiguredThreshold(alertRule)
 
 	if st.applyNoDataAndErrorToAllStates && results.IsNoData() && (alertRule.NoDataState == ngModels.Alerting || alertRule.NoDataState == ngModels.OK || alertRule.NoDataState == ngModels.KeepLast) { // If it is no data, check the mapping and switch all results to the new state
 		// aggregate UID of datasources that returned NoData into one and provide as auxiliary info via annotationa. See: https://github.com/grafana/grafana/issues/88184
@@ -395,14 +395,14 @@ func (st *Manager) setNextStateForRule(ctx context.Context, alertRule *ngModels.
 			"datasource_uid": datasourceUIDs.String(),
 			"ref_id":         refIds.String(),
 		}
-		transitions := st.setNextStateForAll(ctx, alertRule, results[0], logger, annotations, thresholdVal, thresholdOK)
+		transitions := st.setNextStateForAll(ctx, alertRule, results[0], logger, annotations, threshold)
 		if len(transitions) > 0 {
 			return transitions // if there are no current states for the rule. Create ones for each result
 		}
 	}
 	if st.applyNoDataAndErrorToAllStates && results.IsError() && (alertRule.ExecErrState == ngModels.AlertingErrState || alertRule.ExecErrState == ngModels.OkErrState || alertRule.ExecErrState == ngModels.KeepLastErrState) {
 		// TODO squash all errors into one, and provide as annotation
-		transitions := st.setNextStateForAll(ctx, alertRule, results[0], logger, nil, thresholdVal, thresholdOK)
+		transitions := st.setNextStateForAll(ctx, alertRule, results[0], logger, nil, threshold)
 		if len(transitions) > 0 {
 			return transitions // if there are no current states for the rule. Create ones for each result
 		}
@@ -410,14 +410,14 @@ func (st *Manager) setNextStateForRule(ctx context.Context, alertRule *ngModels.
 	transitions := make([]StateTransition, 0, len(results))
 	for _, result := range results {
 		currentState := st.cache.create(ctx, logger, alertRule, result, extraLabels, st.externalURL)
-		s := st.setNextState(ctx, alertRule, currentState, result, nil, logger, thresholdVal, thresholdOK)
+		s := st.setNextState(ctx, alertRule, currentState, result, nil, logger, threshold)
 		st.cache.set(currentState) // replace the existing state with the new one
 		transitions = append(transitions, s)
 	}
 	return transitions
 }
 
-func (st *Manager) setNextStateForAll(ctx context.Context, alertRule *ngModels.AlertRule, result eval.Result, logger log.Logger, extraAnnotations data.Labels, thresholdVal float64, thresholdOK bool) []StateTransition {
+func (st *Manager) setNextStateForAll(ctx context.Context, alertRule *ngModels.AlertRule, result eval.Result, logger log.Logger, extraAnnotations data.Labels, threshold *float64) []StateTransition {
 	currentStates := st.cache.getStatesForRuleUID(alertRule.OrgID, alertRule.UID, false)
 	transitions := make([]StateTransition, 0, len(currentStates))
 	updated := ruleStates{
@@ -425,7 +425,7 @@ func (st *Manager) setNextStateForAll(ctx context.Context, alertRule *ngModels.A
 	}
 	for _, currentState := range currentStates {
 		newState := currentState.Copy()
-		t := st.setNextState(ctx, alertRule, newState, result, extraAnnotations, logger, thresholdVal, thresholdOK)
+		t := st.setNextState(ctx, alertRule, newState, result, extraAnnotations, logger, threshold)
 		updated.states[newState.CacheID] = newState
 		transitions = append(transitions, t)
 	}
@@ -434,16 +434,15 @@ func (st *Manager) setNextStateForAll(ctx context.Context, alertRule *ngModels.A
 }
 
 // Set the current state based on evaluation results
-func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRule, currentState *State, result eval.Result, extraAnnotations data.Labels, logger log.Logger, thresholdVal float64, thresholdOK bool) StateTransition {
+func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRule, currentState *State, result eval.Result, extraAnnotations data.Labels, logger log.Logger, threshold *float64) StateTransition {
 	start := st.clock.Now()
 
 	currentState.LastEvaluationTime = result.EvaluatedAt
 	currentState.EvaluationDuration = result.EvaluationDuration
 	currentState.SetNextValues(result)
 
-	// Inject the pre-computed configured threshold into the Values map.
-	if thresholdOK {
-		currentState.Values[gcConfiguredThresholdKey] = thresholdVal
+	if threshold != nil {
+		currentState.Values[gcConfiguredThresholdKey] = *threshold
 	}
 
 	currentState.LatestResult = &Evaluation{

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -365,6 +365,9 @@ func (st *Manager) updateLastSentAt(states StateTransitions, evaluatedAt time.Ti
 }
 
 func (st *Manager) setNextStateForRule(ctx context.Context, alertRule *ngModels.AlertRule, results eval.Results, extraLabels data.Labels, logger log.Logger) []StateTransition {
+	// Extract the configured threshold once per rule evaluation, not per result.
+	thresholdVal, thresholdOK := extractConfiguredThreshold(alertRule)
+
 	if st.applyNoDataAndErrorToAllStates && results.IsNoData() && (alertRule.NoDataState == ngModels.Alerting || alertRule.NoDataState == ngModels.OK || alertRule.NoDataState == ngModels.KeepLast) { // If it is no data, check the mapping and switch all results to the new state
 		// aggregate UID of datasources that returned NoData into one and provide as auxiliary info via annotationa. See: https://github.com/grafana/grafana/issues/88184
 		var refIds strings.Builder
@@ -392,14 +395,14 @@ func (st *Manager) setNextStateForRule(ctx context.Context, alertRule *ngModels.
 			"datasource_uid": datasourceUIDs.String(),
 			"ref_id":         refIds.String(),
 		}
-		transitions := st.setNextStateForAll(ctx, alertRule, results[0], logger, annotations)
+		transitions := st.setNextStateForAll(ctx, alertRule, results[0], logger, annotations, thresholdVal, thresholdOK)
 		if len(transitions) > 0 {
 			return transitions // if there are no current states for the rule. Create ones for each result
 		}
 	}
 	if st.applyNoDataAndErrorToAllStates && results.IsError() && (alertRule.ExecErrState == ngModels.AlertingErrState || alertRule.ExecErrState == ngModels.OkErrState || alertRule.ExecErrState == ngModels.KeepLastErrState) {
 		// TODO squash all errors into one, and provide as annotation
-		transitions := st.setNextStateForAll(ctx, alertRule, results[0], logger, nil)
+		transitions := st.setNextStateForAll(ctx, alertRule, results[0], logger, nil, thresholdVal, thresholdOK)
 		if len(transitions) > 0 {
 			return transitions // if there are no current states for the rule. Create ones for each result
 		}
@@ -407,14 +410,14 @@ func (st *Manager) setNextStateForRule(ctx context.Context, alertRule *ngModels.
 	transitions := make([]StateTransition, 0, len(results))
 	for _, result := range results {
 		currentState := st.cache.create(ctx, logger, alertRule, result, extraLabels, st.externalURL)
-		s := st.setNextState(ctx, alertRule, currentState, result, nil, logger)
+		s := st.setNextState(ctx, alertRule, currentState, result, nil, logger, thresholdVal, thresholdOK)
 		st.cache.set(currentState) // replace the existing state with the new one
 		transitions = append(transitions, s)
 	}
 	return transitions
 }
 
-func (st *Manager) setNextStateForAll(ctx context.Context, alertRule *ngModels.AlertRule, result eval.Result, logger log.Logger, extraAnnotations data.Labels) []StateTransition {
+func (st *Manager) setNextStateForAll(ctx context.Context, alertRule *ngModels.AlertRule, result eval.Result, logger log.Logger, extraAnnotations data.Labels, thresholdVal float64, thresholdOK bool) []StateTransition {
 	currentStates := st.cache.getStatesForRuleUID(alertRule.OrgID, alertRule.UID, false)
 	transitions := make([]StateTransition, 0, len(currentStates))
 	updated := ruleStates{
@@ -422,7 +425,7 @@ func (st *Manager) setNextStateForAll(ctx context.Context, alertRule *ngModels.A
 	}
 	for _, currentState := range currentStates {
 		newState := currentState.Copy()
-		t := st.setNextState(ctx, alertRule, newState, result, extraAnnotations, logger)
+		t := st.setNextState(ctx, alertRule, newState, result, extraAnnotations, logger, thresholdVal, thresholdOK)
 		updated.states[newState.CacheID] = newState
 		transitions = append(transitions, t)
 	}
@@ -431,12 +434,18 @@ func (st *Manager) setNextStateForAll(ctx context.Context, alertRule *ngModels.A
 }
 
 // Set the current state based on evaluation results
-func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRule, currentState *State, result eval.Result, extraAnnotations data.Labels, logger log.Logger) StateTransition {
+func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRule, currentState *State, result eval.Result, extraAnnotations data.Labels, logger log.Logger, thresholdVal float64, thresholdOK bool) StateTransition {
 	start := st.clock.Now()
 
 	currentState.LastEvaluationTime = result.EvaluatedAt
 	currentState.EvaluationDuration = result.EvaluationDuration
 	currentState.SetNextValues(result)
+
+	// Inject the pre-computed configured threshold into the Values map.
+	if thresholdOK {
+		currentState.Values[gcConfiguredThresholdKey] = thresholdVal
+	}
+
 	currentState.LatestResult = &Evaluation{
 		EvaluationTime:  result.EvaluatedAt,
 		EvaluationState: result.State,

--- a/pkg/services/ngalert/state/threshold_extraction.go
+++ b/pkg/services/ngalert/state/threshold_extraction.go
@@ -1,0 +1,47 @@
+package state
+
+import (
+	"encoding/json"
+
+	"github.com/grafana/grafana/pkg/expr"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+const gcConfiguredThresholdKey = "_gc_configured_threshold"
+
+// extractConfiguredThreshold parses the alert rule's condition query to
+// extract the configured threshold value. Returns (value, true) if found.
+func extractConfiguredThreshold(alertRule *models.AlertRule) (float64, bool) {
+	// Find the condition query by matching alertRule.Condition RefID
+	var conditionQuery *models.AlertQuery
+	for i := range alertRule.Data {
+		if alertRule.Data[i].RefID == alertRule.Condition {
+			conditionQuery = &alertRule.Data[i]
+			break
+		}
+	}
+	if conditionQuery == nil {
+		return 0, false
+	}
+
+	if !expr.IsDataSource(conditionQuery.DatasourceUID) {
+		return 0, false
+	}
+
+	// Single unmarshal: embed type check and threshold config together.
+	var config struct {
+		Type string `json:"type"`
+		expr.ThresholdCommandConfig
+	}
+	if err := json.Unmarshal(conditionQuery.Model, &config); err != nil {
+		return 0, false
+	}
+	if config.Type != string(expr.QueryTypeThreshold) {
+		return 0, false
+	}
+	if len(config.Conditions) == 0 || len(config.Conditions[0].Evaluator.Params) == 0 {
+		return 0, false
+	}
+
+	return config.Conditions[0].Evaluator.Params[0], true
+}

--- a/pkg/services/ngalert/state/threshold_extraction.go
+++ b/pkg/services/ngalert/state/threshold_extraction.go
@@ -10,8 +10,8 @@ import (
 const gcConfiguredThresholdKey = "_gc_configured_threshold"
 
 // extractConfiguredThreshold parses the alert rule's condition query to
-// extract the configured threshold value. Returns (value, true) if found.
-func extractConfiguredThreshold(alertRule *models.AlertRule) (float64, bool) {
+// extract the configured threshold value. Returns nil if not found.
+func extractConfiguredThreshold(alertRule *models.AlertRule) *float64 {
 	// Find the condition query by matching alertRule.Condition RefID
 	var conditionQuery *models.AlertQuery
 	for i := range alertRule.Data {
@@ -21,11 +21,11 @@ func extractConfiguredThreshold(alertRule *models.AlertRule) (float64, bool) {
 		}
 	}
 	if conditionQuery == nil {
-		return 0, false
+		return nil
 	}
 
 	if !expr.IsDataSource(conditionQuery.DatasourceUID) {
-		return 0, false
+		return nil
 	}
 
 	// Single unmarshal: embed type check and threshold config together.
@@ -34,14 +34,15 @@ func extractConfiguredThreshold(alertRule *models.AlertRule) (float64, bool) {
 		expr.ThresholdCommandConfig
 	}
 	if err := json.Unmarshal(conditionQuery.Model, &config); err != nil {
-		return 0, false
+		return nil
 	}
 	if config.Type != string(expr.QueryTypeThreshold) {
-		return 0, false
+		return nil
 	}
 	if len(config.Conditions) == 0 || len(config.Conditions[0].Evaluator.Params) == 0 {
-		return 0, false
+		return nil
 	}
 
-	return config.Conditions[0].Evaluator.Params[0], true
+	v := config.Conditions[0].Evaluator.Params[0]
+	return &v
 }

--- a/pkg/services/ngalert/state/threshold_extraction_test.go
+++ b/pkg/services/ngalert/state/threshold_extraction_test.go
@@ -1,0 +1,194 @@
+package state
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/expr"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+func makeThresholdModel(t *testing.T, evalType string, params []float64) json.RawMessage {
+	t.Helper()
+	m := map[string]any{
+		"type":       "threshold",
+		"expression": "A",
+		"conditions": []map[string]any{
+			{
+				"evaluator": map[string]any{
+					"type":   evalType,
+					"params": params,
+				},
+			},
+		},
+	}
+	b, err := json.Marshal(m)
+	require.NoError(t, err)
+	return b
+}
+
+func TestExtractConfiguredThreshold(t *testing.T) {
+	tests := []struct {
+		name      string
+		rule      *ngmodels.AlertRule
+		wantVal   float64
+		wantFound bool
+	}{
+		{
+			name: "gt threshold",
+			rule: &ngmodels.AlertRule{
+				Condition: "B",
+				Data: []ngmodels.AlertQuery{
+					{RefID: "A", DatasourceUID: "prometheus"},
+					{RefID: "B", DatasourceUID: expr.DatasourceUID, Model: makeThresholdModel(t, "gt", []float64{90})},
+				},
+			},
+			wantVal:   90,
+			wantFound: true,
+		},
+		{
+			name: "lt threshold",
+			rule: &ngmodels.AlertRule{
+				Condition: "B",
+				Data: []ngmodels.AlertQuery{
+					{RefID: "A", DatasourceUID: "prometheus"},
+					{RefID: "B", DatasourceUID: expr.DatasourceUID, Model: makeThresholdModel(t, "lt", []float64{50})},
+				},
+			},
+			wantVal:   50,
+			wantFound: true,
+		},
+		{
+			name: "within_range uses first param",
+			rule: &ngmodels.AlertRule{
+				Condition: "B",
+				Data: []ngmodels.AlertQuery{
+					{RefID: "A", DatasourceUID: "prometheus"},
+					{RefID: "B", DatasourceUID: expr.DatasourceUID, Model: makeThresholdModel(t, "within_range", []float64{10, 100})},
+				},
+			},
+			wantVal:   10,
+			wantFound: true,
+		},
+		{
+			name: "outside_range uses first param",
+			rule: &ngmodels.AlertRule{
+				Condition: "B",
+				Data: []ngmodels.AlertQuery{
+					{RefID: "A", DatasourceUID: "prometheus"},
+					{RefID: "B", DatasourceUID: expr.DatasourceUID, Model: makeThresholdModel(t, "outside_range", []float64{10, 100})},
+				},
+			},
+			wantVal:   10,
+			wantFound: true,
+		},
+		{
+			name: "old datasource UID",
+			rule: &ngmodels.AlertRule{
+				Condition: "B",
+				Data: []ngmodels.AlertQuery{
+					{RefID: "A", DatasourceUID: "prometheus"},
+					{RefID: "B", DatasourceUID: expr.OldDatasourceUID, Model: makeThresholdModel(t, "gt", []float64{42})},
+				},
+			},
+			wantVal:   42,
+			wantFound: true,
+		},
+		{
+			name: "condition RefID not found",
+			rule: &ngmodels.AlertRule{
+				Condition: "C",
+				Data: []ngmodels.AlertQuery{
+					{RefID: "A", DatasourceUID: "prometheus"},
+					{RefID: "B", DatasourceUID: expr.DatasourceUID, Model: makeThresholdModel(t, "gt", []float64{90})},
+				},
+			},
+			wantVal:   0,
+			wantFound: false,
+		},
+		{
+			name: "condition is not expression datasource",
+			rule: &ngmodels.AlertRule{
+				Condition: "A",
+				Data: []ngmodels.AlertQuery{
+					{RefID: "A", DatasourceUID: "prometheus", Model: makeThresholdModel(t, "gt", []float64{90})},
+				},
+			},
+			wantVal:   0,
+			wantFound: false,
+		},
+		{
+			name: "condition is math type not threshold",
+			rule: &ngmodels.AlertRule{
+				Condition: "B",
+				Data: []ngmodels.AlertQuery{
+					{RefID: "A", DatasourceUID: "prometheus"},
+					{RefID: "B", DatasourceUID: expr.DatasourceUID, Model: func() json.RawMessage {
+						m := map[string]any{
+							"type":       "math",
+							"expression": "$A > 90",
+						}
+						b, _ := json.Marshal(m)
+						return b
+					}()},
+				},
+			},
+			wantVal:   0,
+			wantFound: false,
+		},
+		{
+			name: "empty conditions array",
+			rule: &ngmodels.AlertRule{
+				Condition: "B",
+				Data: []ngmodels.AlertQuery{
+					{RefID: "A", DatasourceUID: "prometheus"},
+					{RefID: "B", DatasourceUID: expr.DatasourceUID, Model: func() json.RawMessage {
+						m := map[string]any{
+							"type":       "threshold",
+							"expression": "A",
+							"conditions": []map[string]any{},
+						}
+						b, _ := json.Marshal(m)
+						return b
+					}()},
+				},
+			},
+			wantVal:   0,
+			wantFound: false,
+		},
+		{
+			name: "empty params",
+			rule: &ngmodels.AlertRule{
+				Condition: "B",
+				Data: []ngmodels.AlertQuery{
+					{RefID: "A", DatasourceUID: "prometheus"},
+					{RefID: "B", DatasourceUID: expr.DatasourceUID, Model: makeThresholdModel(t, "gt", []float64{})},
+				},
+			},
+			wantVal:   0,
+			wantFound: false,
+		},
+		{
+			name: "malformed model JSON",
+			rule: &ngmodels.AlertRule{
+				Condition: "B",
+				Data: []ngmodels.AlertQuery{
+					{RefID: "B", DatasourceUID: expr.DatasourceUID, Model: json.RawMessage(`{invalid json}`)},
+				},
+			},
+			wantVal:   0,
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, found := extractConfiguredThreshold(tt.rule)
+			assert.Equal(t, tt.wantFound, found)
+			assert.Equal(t, tt.wantVal, val)
+		})
+	}
+}

--- a/pkg/services/ngalert/state/threshold_extraction_test.go
+++ b/pkg/services/ngalert/state/threshold_extraction_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/expr"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 func makeThresholdModel(t *testing.T, evalType string, params []float64) json.RawMessage {
@@ -32,10 +33,9 @@ func makeThresholdModel(t *testing.T, evalType string, params []float64) json.Ra
 
 func TestExtractConfiguredThreshold(t *testing.T) {
 	tests := []struct {
-		name      string
-		rule      *ngmodels.AlertRule
-		wantVal   float64
-		wantFound bool
+		name string
+		rule *ngmodels.AlertRule
+		want *float64
 	}{
 		{
 			name: "gt threshold",
@@ -46,8 +46,7 @@ func TestExtractConfiguredThreshold(t *testing.T) {
 					{RefID: "B", DatasourceUID: expr.DatasourceUID, Model: makeThresholdModel(t, "gt", []float64{90})},
 				},
 			},
-			wantVal:   90,
-			wantFound: true,
+			want: util.Pointer[float64](90),
 		},
 		{
 			name: "lt threshold",
@@ -58,8 +57,7 @@ func TestExtractConfiguredThreshold(t *testing.T) {
 					{RefID: "B", DatasourceUID: expr.DatasourceUID, Model: makeThresholdModel(t, "lt", []float64{50})},
 				},
 			},
-			wantVal:   50,
-			wantFound: true,
+			want: util.Pointer[float64](50),
 		},
 		{
 			name: "within_range uses first param",
@@ -70,8 +68,7 @@ func TestExtractConfiguredThreshold(t *testing.T) {
 					{RefID: "B", DatasourceUID: expr.DatasourceUID, Model: makeThresholdModel(t, "within_range", []float64{10, 100})},
 				},
 			},
-			wantVal:   10,
-			wantFound: true,
+			want: util.Pointer[float64](10),
 		},
 		{
 			name: "outside_range uses first param",
@@ -82,8 +79,7 @@ func TestExtractConfiguredThreshold(t *testing.T) {
 					{RefID: "B", DatasourceUID: expr.DatasourceUID, Model: makeThresholdModel(t, "outside_range", []float64{10, 100})},
 				},
 			},
-			wantVal:   10,
-			wantFound: true,
+			want: util.Pointer[float64](10),
 		},
 		{
 			name: "old datasource UID",
@@ -94,8 +90,7 @@ func TestExtractConfiguredThreshold(t *testing.T) {
 					{RefID: "B", DatasourceUID: expr.OldDatasourceUID, Model: makeThresholdModel(t, "gt", []float64{42})},
 				},
 			},
-			wantVal:   42,
-			wantFound: true,
+			want: util.Pointer[float64](42),
 		},
 		{
 			name: "condition RefID not found",
@@ -106,8 +101,7 @@ func TestExtractConfiguredThreshold(t *testing.T) {
 					{RefID: "B", DatasourceUID: expr.DatasourceUID, Model: makeThresholdModel(t, "gt", []float64{90})},
 				},
 			},
-			wantVal:   0,
-			wantFound: false,
+			want: nil,
 		},
 		{
 			name: "condition is not expression datasource",
@@ -117,8 +111,7 @@ func TestExtractConfiguredThreshold(t *testing.T) {
 					{RefID: "A", DatasourceUID: "prometheus", Model: makeThresholdModel(t, "gt", []float64{90})},
 				},
 			},
-			wantVal:   0,
-			wantFound: false,
+			want: nil,
 		},
 		{
 			name: "condition is math type not threshold",
@@ -136,8 +129,7 @@ func TestExtractConfiguredThreshold(t *testing.T) {
 					}()},
 				},
 			},
-			wantVal:   0,
-			wantFound: false,
+			want: nil,
 		},
 		{
 			name: "empty conditions array",
@@ -156,8 +148,7 @@ func TestExtractConfiguredThreshold(t *testing.T) {
 					}()},
 				},
 			},
-			wantVal:   0,
-			wantFound: false,
+			want: nil,
 		},
 		{
 			name: "empty params",
@@ -168,8 +159,7 @@ func TestExtractConfiguredThreshold(t *testing.T) {
 					{RefID: "B", DatasourceUID: expr.DatasourceUID, Model: makeThresholdModel(t, "gt", []float64{})},
 				},
 			},
-			wantVal:   0,
-			wantFound: false,
+			want: nil,
 		},
 		{
 			name: "malformed model JSON",
@@ -179,16 +169,14 @@ func TestExtractConfiguredThreshold(t *testing.T) {
 					{RefID: "B", DatasourceUID: expr.DatasourceUID, Model: json.RawMessage(`{invalid json}`)},
 				},
 			},
-			wantVal:   0,
-			wantFound: false,
+			want: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			val, found := extractConfiguredThreshold(tt.rule)
-			assert.Equal(t, tt.wantFound, found)
-			assert.Equal(t, tt.wantVal, val)
+			got := extractConfiguredThreshold(tt.rule)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
Inject _gc_configured_threshold into the alert state Values map so dispatch-center can populate {{threshold}} in notification templates. Parses the threshold from the rule's condition query model server-side as a fallback independent of the router-injected math expression query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Precompute and propagate configured alert thresholds during state evaluation so thresholds are attached to updated states and included in result metadata.
  * Extended internal state-update flows to accept and forward extracted threshold values.

* **Tests**
  * Added comprehensive tests covering extraction of configured thresholds from alert rules, including success and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->