### PR TITLE
BE-2008: resolve label dot-notation collisions in Jinja2 summary templates (+ panic guard + sandbox)

### DIFF
--- a/pkg/services/ngalert/state/template/jinja2.go
+++ b/pkg/services/ngalert/state/template/jinja2.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 
@@ -18,31 +19,66 @@ func (l NestedLabels) String() string {
 		return ""
 	}
 
-	// Collect only leaf string values (original flat keys), skip nested map entries.
+	// Render scalar leaves only: plain string labels and labelMap nodes that carry a
+	// scalar of their own (a label that is also a namespace). Pure namespace nodes are skipped.
 	keys := make([]string, 0, len(l))
 	for k, v := range l {
-		if _, isMap := v.(map[string]interface{}); !isMap {
+		switch val := v.(type) {
+		case string:
 			keys = append(keys, k)
+		case labelMap:
+			if _, ok := val.raw(); ok {
+				keys = append(keys, k)
+			}
 		}
 	}
 	sort.Strings(keys)
 
 	pairs := make([]string, 0, len(keys))
 	for _, k := range keys {
+		// %s uses labelMap.String() (its scalar) for nodes, or the plain string value.
 		pairs = append(pairs, fmt.Sprintf("%s=%s", k, l[k]))
 	}
 	return strings.Join(pairs, ", ")
 }
 
-// BuildNestedLabels converts a flat Labels map into a NestedLabels that
-// supports both bracket notation and dot notation for keys containing dots.
+// rawValueKey is the sentinel map key under which a labelMap stores its own scalar
+// value. The NUL byte guarantees it can never collide with a real label segment
+// (label keys never contain NUL bytes).
+const rawValueKey = "\x00raw"
+
+// labelMap represents a label that is simultaneously a scalar value and a namespace.
+// It is map-kinded so pongo2 resolves nested keys ({{ labels.error.message }}), and
+// implements fmt.Stringer so direct output ({{ labels.error }}) renders the node's own
+// scalar value instead of a Go map dump. This lets a flat label like "error" coexist
+// with a dotted label "error.message" without the dot-access collision that a plain
+// string value would otherwise cause.
+type labelMap map[string]interface{}
+
+// String renders the node's own scalar value, or empty if it is a pure namespace.
+func (m labelMap) String() string {
+	raw, _ := m.raw()
+	return raw
+}
+
+// raw reports the node's own scalar value and whether it has one.
+func (m labelMap) raw() (string, bool) {
+	v, ok := m[rawValueKey].(string)
+	return v, ok
+}
+
+// BuildNestedLabels converts a flat Labels map into a NestedLabels that supports both
+// bracket notation (labels["a.b"]) and dot notation (labels.a.b) for keys containing
+// dots. When a key is both a value and a namespace prefix of another key (e.g. "error"
+// alongside "error.message"), the value is preserved as a labelMap node so that both
+// {{ labels.error }} and {{ labels.error.message }} resolve.
 //
-// For a flat map like {"http.route": "/api", "env": "prod"}, the result is:
+// For {"http.route": "/api", "env": "prod"} the result is:
 //
 //	{
-//	  "http.route": "/api",          // flat key preserved for labels["http.route"]
-//	  "http": {"route": "/api"},     // nested entry for labels.http.route
-//	  "env": "prod",                 // simple key, works both ways
+//	  "http.route": "/api",                // flat key preserved for labels["http.route"]
+//	  "http": labelMap{"route": "/api"},   // nested node for labels.http.route
+//	  "env": "prod",                       // simple key, works both ways
 //	}
 func BuildNestedLabels(labels Labels) NestedLabels {
 	if len(labels) == 0 {
@@ -51,26 +87,21 @@ func BuildNestedLabels(labels Labels) NestedLabels {
 
 	result := make(NestedLabels, len(labels)*2)
 
-	// First pass: add all original flat keys (preserves bracket notation).
+	// Seed every original flat key so bracket notation (labels["a.b"]) always works.
 	for k, v := range labels {
 		result[k] = v
 	}
 
-	// Second pass: build nested structure for dotted keys (enables dot notation).
-	// If an intermediate segment conflicts with an existing flat leaf value,
-	// we skip building the nested path for that key to preserve backward compatibility.
-	//
-	// Keys are sorted by segment count (fewer segments first) to ensure deterministic
-	// behavior when keys overlap (e.g., "a.b" and "a.b.c"). Shorter keys are processed
-	// first so they claim their leaf position, and deeper keys correctly detect the conflict.
+	// Build nested labelMap structure for dotted keys. Process keys with fewer
+	// segments first so a shorter key ("a.b") settles before a deeper one ("a.b.c")
+	// descends through it, keeping construction deterministic.
 	type dottedKey struct {
 		key   string
 		parts []string
 	}
 	var dottedKeys []dottedKey
 	for k := range labels {
-		parts := strings.Split(k, ".")
-		if len(parts) > 1 {
+		if parts := strings.Split(k, "."); len(parts) > 1 {
 			dottedKeys = append(dottedKeys, dottedKey{key: k, parts: parts})
 		}
 	}
@@ -82,30 +113,39 @@ func BuildNestedLabels(labels Labels) NestedLabels {
 	})
 
 	for _, dk := range dottedKeys {
-		current := map[string]interface{}(result)
-		conflict := false
+		var current map[string]interface{} = result
+		// Walk/create intermediate nodes, promoting any colliding scalar into a node.
 		for _, part := range dk.parts[:len(dk.parts)-1] {
-			if existing, ok := current[part]; ok {
-				if nestedMap, ok := existing.(map[string]interface{}); ok {
-					current = nestedMap
-				} else {
-					// Intermediate part exists as a flat leaf value (e.g., "github" is a simple label).
-					// Skip building nested path to avoid overwriting the leaf.
-					conflict = true
-					break
-				}
-			} else {
-				nested := make(map[string]interface{})
-				current[part] = nested
-				current = nested
-			}
+			current = promoteToNode(current, part)
 		}
-		if !conflict {
-			current[dk.parts[len(dk.parts)-1]] = labels[dk.key]
+		// Place the leaf value. If a deeper key already created a node here, attach
+		// this key's scalar to that node rather than overwriting it.
+		leaf := dk.parts[len(dk.parts)-1]
+		if node, ok := current[leaf].(labelMap); ok {
+			node[rawValueKey] = labels[dk.key]
+		} else {
+			current[leaf] = labels[dk.key]
 		}
 	}
 
 	return result
+}
+
+// promoteToNode returns the labelMap stored at m[key], creating it if absent and
+// promoting a pre-existing scalar value into the node's scalar slot so it survives.
+func promoteToNode(m map[string]interface{}, key string) labelMap {
+	switch existing := m[key].(type) {
+	case labelMap:
+		return existing
+	case nil:
+		node := labelMap{}
+		m[key] = node
+		return node
+	default: // scalar — a flat label that is also a namespace prefix
+		node := labelMap{rawValueKey: existing}
+		m[key] = node
+		return node
+	}
 }
 
 func init() {
@@ -113,6 +153,65 @@ func init() {
 	// Auto-escaping is disabled because summary templates are used for plain text output,
 	// not HTML rendering, so we want raw string values without HTML entity encoding.
 	pongo2.SetAutoescape(false)
+}
+
+// maxTemplateSize bounds user-provided summary templates (10 KB).
+const maxTemplateSize = 10 * 1024
+
+// bannedTags are pongo2 tags capable of reading local files. They must never be
+// available in user-provided summary templates.
+var bannedTags = []string{
+	"include", // {% include "file" %} — loads and renders a template file
+	"ssi",     // {% ssi "file" %}     — server-side include, reads file content
+	"extends", // {% extends "file" %} — inherits from a parent template file
+	"import",  // {% import "file" %}  — imports macros from a template file
+}
+
+// denyLoader is a pongo2.TemplateLoader that rejects all filesystem access.
+// pongo2.NewSet requires a loader, so we supply one that always errors.
+type denyLoader struct{}
+
+func (denyLoader) Abs(base, name string) string { return name }
+func (denyLoader) Get(string) (io.Reader, error) {
+	return nil, fmt.Errorf("template loading from filesystem is disabled")
+}
+
+// sandboxSet is a pongo2 TemplateSet with file-reading tags banned and filesystem
+// access denied, so a summary template cannot exfiltrate local files.
+var sandboxSet = newSandboxSet()
+
+func newSandboxSet() *pongo2.TemplateSet {
+	set := pongo2.NewSet("ngalert-jinja2-sandbox", denyLoader{})
+	for _, tag := range bannedTags {
+		if err := set.BanTag(tag); err != nil {
+			panic(fmt.Sprintf("jinja2 sandbox: failed to ban tag %q: %v", tag, err))
+		}
+	}
+	return set
+}
+
+// sandboxedFromString parses a template through the sandboxed set, rejecting
+// over-sized templates and any use of the banned file-reading tags.
+func sandboxedFromString(tmpl string) (*pongo2.Template, error) {
+	if len(tmpl) > maxTemplateSize {
+		return nil, fmt.Errorf("template exceeds maximum size of %d bytes", maxTemplateSize)
+	}
+	return sandboxSet.FromString(tmpl)
+}
+
+// safeExecute runs tpl.Execute but converts a pongo2 panic into an error. pongo2
+// panics (rather than returning an error) on some malformed expressions — notably an
+// unquoted bracket subscript like {{ labels[key] }} — which would otherwise crash the
+// caller's goroutine. Recovering keeps summary expansion fail-safe.
+func safeExecute(tpl *pongo2.Template, ctx pongo2.Context) (result string, err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			result = ""
+			err = fmt.Errorf("template execution panicked: %v "+
+				"(a likely cause is unquoted bracket access such as labels[key]; quote the key: labels[\"key\"])", rec)
+		}
+	}()
+	return tpl.Execute(ctx)
 }
 
 type SummaryContext struct {
@@ -156,12 +255,12 @@ func ExpandJinja2Summary(tmpl string, ctx SummaryContext) (string, error) {
 		},
 	}
 
-	tpl, err := pongo2.FromString(tmpl)
+	tpl, err := sandboxedFromString(tmpl)
 	if err != nil {
 		return "", ExpandError{Tmpl: tmpl, Err: err}
 	}
 
-	result, err := tpl.Execute(pongoCtx)
+	result, err := safeExecute(tpl, pongoCtx)
 	if err != nil {
 		return "", ExpandError{Tmpl: tmpl, Err: err}
 	}

--- a/pkg/services/ngalert/state/template/jinja2_test.go
+++ b/pkg/services/ngalert/state/template/jinja2_test.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -297,7 +298,7 @@ func TestExpandJinja2Summary_BracketNotationPreserved(t *testing.T) {
 	require.Equal(t, "Route: /api/v1/users", result)
 }
 
-func TestExpandJinja2Summary_DotNotationConflict(t *testing.T) {
+func TestExpandJinja2Summary_DotNotationCollisionResolves(t *testing.T) {
 	ctx := SummaryContext{
 		Labels: Labels{
 			"github":          "myorg",
@@ -305,19 +306,48 @@ func TestExpandJinja2Summary_DotNotationConflict(t *testing.T) {
 		},
 	}
 
-	// Flat leaf value wins — dot notation resolves to the simple label.
+	// Direct access to the colliding label renders its own scalar.
 	result, err := ExpandJinja2Summary("Org: {{ labels.github }}", ctx)
 	require.NoError(t, err)
 	require.Equal(t, "Org: myorg", result)
 
-	// Dot notation for the conflicted key errors (pongo2 can't traverse a string).
-	_, err = ExpandJinja2Summary("Workflow: {{ labels.github.workflow }}", ctx)
-	require.Error(t, err)
+	// Dot notation into the same name now resolves instead of erroring.
+	result, err = ExpandJinja2Summary("Workflow: {{ labels.github.workflow }}", ctx)
+	require.NoError(t, err)
+	require.Equal(t, "Workflow: CI", result)
 
-	// Bracket notation still works as the fallback for conflicted dotted keys.
+	// Bracket notation keeps working too.
 	result, err = ExpandJinja2Summary(`Workflow: {{ labels["github.workflow"] }}`, ctx)
 	require.NoError(t, err)
 	require.Equal(t, "Workflow: CI", result)
+}
+
+func TestExpandJinja2Summary_UnquotedBracketDoesNotPanic(t *testing.T) {
+	ctx := SummaryContext{Labels: Labels{"errType": "Timeout"}}
+
+	// Unquoted bracket access panics inside pongo2; it must surface as an error,
+	// not crash the caller.
+	_, err := ExpandJinja2Summary("{{ labels[errType] }}", ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "panicked")
+	require.Contains(t, err.Error(), "quote the key")
+}
+
+func TestExpandJinja2Summary_SandboxBlocksFileTags(t *testing.T) {
+	ctx := SummaryContext{Labels: Labels{"env": "prod"}}
+
+	for _, tmpl := range []string{
+		`{{ x }}{% include "/etc/passwd" %}`,
+		`{{ x }}{% ssi "/etc/passwd" %}`,
+		`{% extends "/etc/passwd" %}{{ x }}`,
+	} {
+		_, err := ExpandJinja2Summary(tmpl, ctx)
+		require.Error(t, err, "file-reading tag must be rejected: %s", tmpl)
+	}
+
+	// Oversized templates are rejected.
+	_, err := ExpandJinja2Summary("{{ "+strings.Repeat("x", maxTemplateSize)+" }}", ctx)
+	require.Error(t, err)
 }
 
 func TestExpandJinja2Summary_MixedSimpleAndDottedKeys(t *testing.T) {
@@ -349,7 +379,7 @@ func TestBuildNestedLabels(t *testing.T) {
 	t.Run("dotted key creates flat and nested entries", func(t *testing.T) {
 		result := BuildNestedLabels(Labels{"http.route": "/api"})
 		require.Equal(t, "/api", result["http.route"])
-		httpMap, ok := result["http"].(map[string]interface{})
+		httpMap, ok := result["http"].(labelMap)
 		require.True(t, ok)
 		require.Equal(t, "/api", httpMap["route"])
 	})
@@ -357,31 +387,41 @@ func TestBuildNestedLabels(t *testing.T) {
 	t.Run("deep nesting", func(t *testing.T) {
 		result := BuildNestedLabels(Labels{"a.b.c": "val"})
 		require.Equal(t, "val", result["a.b.c"])
-		aMap := result["a"].(map[string]interface{})
-		bMap := aMap["b"].(map[string]interface{})
+		aMap := result["a"].(labelMap)
+		bMap := aMap["b"].(labelMap)
 		require.Equal(t, "val", bMap["c"])
 	})
 
-	t.Run("conflict preserves flat leaf", func(t *testing.T) {
+	t.Run("collision keeps both scalar and child", func(t *testing.T) {
 		result := BuildNestedLabels(Labels{
 			"github":          "myorg",
 			"github.workflow": "CI",
 		})
-		require.Equal(t, "myorg", result["github"])
 		require.Equal(t, "CI", result["github.workflow"])
+		node, ok := result["github"].(labelMap)
+		require.True(t, ok, "'github' should be a node carrying scalar + child")
+		raw, hasRaw := node.raw()
+		require.True(t, hasRaw)
+		require.Equal(t, "myorg", raw)
+		require.Equal(t, "CI", node["workflow"])
 	})
 
-	t.Run("overlapping dotted keys are deterministic", func(t *testing.T) {
-		// "a.b" (2 segments) is always processed before "a.b.c" (3 segments),
-		// so "a.b" claims the leaf and "a.b.c" nesting is skipped.
+	t.Run("overlapping dotted keys are deterministic and both resolve", func(t *testing.T) {
+		// "a.b" (2 segments) settles before "a.b.c" (3 segments); the deeper key
+		// promotes "a.b" into a node so both a.b and a.b.c resolve, deterministically.
 		for i := 0; i < 100; i++ {
 			result := BuildNestedLabels(Labels{
 				"a.b":   "1",
 				"a.b.c": "2",
 			})
-			aMap, ok := result["a"].(map[string]interface{})
-			require.True(t, ok, "iteration %d: result[\"a\"] should be a map", i)
-			require.Equal(t, "1", aMap["b"], "iteration %d: shorter key a.b must always win", i)
+			a, ok := result["a"].(labelMap)
+			require.True(t, ok, "iteration %d: result[\"a\"] should be a labelMap", i)
+			ab, ok := a["b"].(labelMap)
+			require.True(t, ok, "iteration %d: a.b should be a node with scalar + child", i)
+			raw, hasRaw := ab.raw()
+			require.True(t, hasRaw, "iteration %d: a.b must keep its scalar", i)
+			require.Equal(t, "1", raw, "iteration %d", i)
+			require.Equal(t, "2", ab["c"], "iteration %d", i)
 			require.Equal(t, "1", result["a.b"])
 			require.Equal(t, "2", result["a.b.c"])
 		}


### PR DESCRIPTION
## description

The grafana fork has its own pongo2/Jinja2 summary-template path at `pkg/services/ngalert/state/template/jinja2.go` (`ExpandJinja2Summary`, used by the state historian → Loki). Its `BuildNestedLabels` was a verbatim copy of the **old, pre-fix** dispatch-center code and carried the same bugs. This ports the fix from [BE-2007](https://linear.app/groundcover/issue/BE-2007) (groundcover-private dispatch-center).

- **Resolve dot-notation collisions structurally.** When a label name is a prefix of another (e.g. an `error` JSON blob alongside `error.message`), `{{ labels.error.message }}` used to fail because `labels.error` resolved to a string. Such a label is now a `labelMap` node — map-kinded so pongo2 resolves nested keys, `fmt.Stringer` so direct output renders its own scalar. Both `{{ labels.error }}` (the blob) and `{{ labels.error.message }}` (the nested value) resolve. No error, no bracket notation required.
- **Panic guard.** `safeExecute` wraps `Execute` in a `recover()`; the unquoted-bracket `{{ labels[key] }}` pongo2 panic now degrades to an error instead of crashing the caller.
- **Sandbox.** The pongo2 `TemplateSet` now bans `include`/`extends`/`ssi`/`import`, denies the filesystem loader, and caps template size — closing a file-read gap (`{% include "/etc/passwd" %}`) that the previous raw `pongo2.FromString` allowed. Matches dispatch-center's `pongo2sandbox`.

Linear: [BE-2008](https://linear.app/groundcover/issue/BE-2008)

## how I tested it

- `go test ./pkg/services/ngalert/state/template/` — pass; `go vet` + `gofmt` clean.
- Added/updated tests: collision now resolves (direct + dotted + bracket); unquoted bracket no longer panics; sandbox rejects `include`/`ssi`/`extends` and oversized templates; updated the prior overlapping-key tests to resolve-both semantics.

## reviewer should start here

1. `pkg/services/ngalert/state/template/jinja2.go` — `labelMap` node + rewritten `BuildNestedLabels`, the sandboxed `TemplateSet`, and `safeExecute`.
2. `pkg/services/ngalert/state/template/jinja2_test.go` — updated expectations + new coverage.

## compatibility

No currently-working template changes output. Only previously-broken cases change: the collision resolves instead of erroring, and the unquoted-bracket panic is caught. (One cosmetic edge: rendering a pure-namespace prefix directly now yields empty instead of a Go map dump.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of conflicting label keys in Jinja2 template expansion for alert summaries
  * Enhanced error handling for template syntax issues, preventing crashes

* **New Features**
  * Added security safeguards to Jinja2 template execution, preventing file-reading operations
  * Implemented size limits on templates to prevent resource exhaustion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->